### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: "Checkout primary repository"
         uses: actions/checkout@v4
 
-      - name: "Pull devops content from repository"
+      - name: "Pull workflows from central repository"
         uses: actions/checkout@v4
         with:
           repository: "os-climate/devops-toolkit"
@@ -173,20 +173,16 @@ jobs:
               "41898282+github-actions[bot]@users.noreply.github.com"
           fi
 
-          # Only if NOT running in GitHub
-          # (checkout is otherwise performed by earlier steps)
-          if [ -z ${GITHUB_RUN_ID+x} ]; then
-            # Remove any stale local copy of the upstream repository
-            if [ -d "$DEVOPS_DIR" ]; then
-              rm -Rf "$DEVOPS_DIR"
-            fi
+          # Remove any stale copy of the upstream repository
+          if [ -d "$DEVOPS_DIR" ]; then
+            rm -Rf "$DEVOPS_DIR"
+          fi
 
-            printf "Cloning DevOps repository into: %s" "$DEVOPS_DIR"
-            if (git clone "$DEVOPS_REPO" "$DEVOPS_DIR" > /dev/null 2>&1); then
-                echo " [success]"
-            else
-                echo " [failed]"; exit 1
-            fi
+          printf "Cloning DevOps repository into: %s" "$DEVOPS_DIR"
+          if (git clone "$DEVOPS_REPO" "$DEVOPS_DIR" > /dev/null 2>&1); then
+              echo " [success]"
+          else
+              echo " [failed]"; exit 1
           fi
 
           # Process upstream DevOps repository content and update


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit