### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -1,0 +1,62 @@
+---
+# Run all notebooks on every push
+name: "🗒️ Build notebooks"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+
+  parse-project-metadata:
+    name: "Determine Python versions"
+    # yamllint disable-line rule:line-length
+    uses: os-climate/devops-reusable-workflows/.github/workflows/pyproject-toml-fetch-matrix.yaml@main
+
+  notebook-build:
+    name: "Build and test Notebooks"
+    needs: [parse-project-metadata]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    # Don't run when pull request is merged
+    if: github.event.pull_request.merged == false
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parse-project-metadata.outputs.matrix) }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: "Setup PDM for build commands"
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: "Install dependencies"
+        run: |
+          which python; which python3
+          python --version; python3 --version
+          python -m pip install --upgrade pip
+          pdm export -o requirements.txt
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install .
+          pip install pytest nbmake
+
+      - name: "Test notebooks: pytest --nbmake"
+        run: pytest --nbmake -- **/*ipynb
+
+      - name: Upload logs as artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-logs
+          path: /tmp/*.log
+          retention-days: 14


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit