### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
         additional_dependencies: ["tomli"]
 
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-    rev: v1.7.1.15
+    rev: v1.7.0.14
     hooks:
       - id: actionlint
 
@@ -104,7 +104,7 @@ repos:
         args: [ "-d", "{rules: {line-length: {max: 120}}, ignore-from-file: [.gitignore],}", ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.4.5
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit