### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -34,7 +34,9 @@ jobs:
           pip install pre-commit mypy
 
       - name: "Run mypy using pre-commit"
-        run: pre-commit run mypy -a
+        run: |
+          if [ ! -d .mypy_cache ]; then /bin/mkdir .mypy_cache; fi
+          pre-commit run mypy -a
 
         # yamllint disable rule:line-length
         # yamllint disable rule:comments-indentation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,12 +86,12 @@ repos:
         additional_dependencies: ["tomli"]
 
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-    rev: v1.7.0.14
+    rev: v1.7.1.15
     hooks:
       - id: actionlint
 
   - repo: https://github.com/pycqa/flake8
-    rev: "7.0.0"
+    rev: "7.1.0"
     hooks:
       - id: flake8
         additional_dependencies:
@@ -104,13 +104,21 @@ repos:
         args: [ "-d", "{rules: {line-length: {max: 120}}, ignore-from-file: [.gitignore],}", ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.5
+    rev: v0.4.9
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
         files: ^(scripts|tests|custom_components)/.+\.py$
+
+  - repo: local
+    hooks:
+      - id: mypy-cache
+        name: "create mypy cache"
+        language: system
+        pass_filenames: false
+        entry: bash -c 'if [ ! -d .mypy_cache ]; then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit