### PR TITLE
Chore: Rename GHA version pins workflow

### DIFF
--- a/.github/workflows/verify-github-actions.yaml
+++ b/.github/workflows/verify-github-actions.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
 # Verifies action/workflow calls are pinned to SHA commits
-name: 📌 GitHub Actions
+name: 📌 Audit GitHub Actions
 
 on:
   workflow_dispatch:
@@ -22,9 +22,6 @@ concurrency:
 jobs:
   check-actions:
     name: Pinned Versions
-    runs-on: ubuntu-22.04
+    uses: os-climate/osc-github-devops/.github/workflows/reuse-pinned-versions.yaml@main
     permissions:
       contents: read
-    steps:
-      - name: Check Pinned Versions
-        uses: os-climate/osc-github-devops/.github/actions/pinned-versions-action@main


### PR DESCRIPTION
Also, convert to use upstream re-usable